### PR TITLE
Fix prod versions of negative values (e.g. negativeMargin)

### DIFF
--- a/src/dynamic-styles.js
+++ b/src/dynamic-styles.js
@@ -70,21 +70,23 @@ export default {
   my: { prop: ['marginTop', 'marginBottom'], config: 'margin' },
   m: { prop: 'margin', config: 'margin' },
 
-  '-mt': { prop: 'marginTop', config: 'negativeMargin', pre: '"-"+' },
-  '-mr': { prop: 'marginRight', config: 'negativeMargin', pre: '"-"+' },
-  '-mb': { prop: 'marginBottom', config: 'negativeMargin', pre: '"-"+' },
-  '-ml': { prop: 'marginLeft', config: 'negativeMargin', pre: '"-"+' },
+  '-mt': { prop: 'marginTop', config: 'negativeMargin', preDev: '"-"+', pre: "-" },
+  '-mr': { prop: 'marginRight', config: 'negativeMargin', preDev: '"-"+', pre: "-" },
+  '-mb': { prop: 'marginBottom', config: 'negativeMargin', preDev: '"-"+', pre: "-" },
+  '-ml': { prop: 'marginLeft', config: 'negativeMargin', preDev: '"-"+', pre: "-" },
   '-mx': {
     prop: ['marginLeft', 'marginRight'],
     config: 'negativeMargin',
-    pre: '"-"+'
+    preDev: '"-"+',
+    pre: "-"
   },
   '-my': {
     prop: ['marginTop', 'marginBottom'],
     config: 'negativeMargin',
-    pre: '"-"+'
+    preDev: '"-"+',
+    pre: "-"
   },
-  '-m': { prop: 'margin', config: 'negativeMargin', pre: '"-"+' },
+  '-m': { prop: 'margin', config: 'negativeMargin', preDev: '"-"+', pre: "-" },
 
   // https://tailwindcss.com/docs/svg
   fill: { prop: 'fill', config: 'svgFill' },


### PR DESCRIPTION
## Summary

When trying to use negative styles, the version evaluated in production builds was not correct.

Fix for: https://github.com/bradlc/babel-plugin-tailwind-components/issues/57

## The Bug
For example with the following code: 

```js
const Container = styled.div`
  ${tw`-m-4`}
`
```

This would evaluate in development environments to this:

```js
"marginTop": "-" + _tailwind32.default.negativeMargin["4"]
```

However in production, it created

```js
"marginTop": "\"-\"+1rem"
```

Here is chrome not liking the built style in prod

![image](https://user-images.githubusercontent.com/18057994/92584313-63fb2200-f28b-11ea-96f8-79ff8bcd8220.png)

## The Fix

Adding a development version of the `pre` attribute lets us evaluate it differently.

For example 

```js
'-mt': { prop: 'marginTop', config: 'negativeMargin', preDev: '"-"+', pre: "-" },
```

In development it still evaluates to the same value 

```js
"marginTop": "-" + _tailwind32.default.negativeMargin["4"]
```

And in production it creates

```js
"marginTop": "-1rem"
```